### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Include the stylesheet on your document's `<head>`
 ```html
 <head>
   <link rel="stylesheet" href="/box-shadows.css">
-  <!-- or -->
-  <link rel="stylesheet" href="/box-shadows.min.css">
+  <!-- or include it directly via CDN -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/box-shadows-css@1/box-shadows.min.css">
 </head>
 ```
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is the same as downloading it but easier and faster.